### PR TITLE
Conditionally transform columns according to statistics

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnTransformer.java
@@ -20,11 +20,21 @@ package org.apache.parquet.hadoop;
 
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
 /**
  * Transformer of column values
  */
 public interface ColumnTransformer {
+
+  /**
+   * Checks whether a column should be transformed given its statistics.
+   *
+   * @param statistics Statistics of the column to transform
+   * @return Whether to transform the column
+   */
+  boolean shouldTransform(Statistics statistics);
 
   /**
    * Writes a transformed column value.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -61,6 +61,7 @@ import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.*;
 import org.apache.parquet.format.DataPageHeader;
 import org.apache.parquet.format.DataPageHeaderV2;
@@ -566,6 +567,10 @@ public class ParquetFileReader implements Closeable {
 
     ColumnDescriptor getColumnDescriptor() {
       return descriptor.col;
+    }
+
+    Statistics getStatistics() {
+      return descriptor.metadata.getStatistics();
     }
 
     protected PageHeader readPageHeader() throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -506,6 +506,13 @@ public class ParquetFileReader implements Closeable {
     ++currentBlock;
   }
 
+  public void appendCurrentBlock(ParquetFileWriter writer) throws IOException {
+    if (currentBlock < blocks.size()) {
+      final BlockMetaData block = blocks.get(currentBlock);
+      writer.appendRowGroup(f, block, true);
+    }
+  }
+
   /**
    * Reads all the columns requested from the row group at the current file position.
    * @throws IOException if an error occurs while reading

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java
@@ -27,13 +27,11 @@ import org.apache.parquet.column.page.CopyPageVisitor;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageWriter;
+import org.apache.parquet.hadoop.CodecFactory.BytesCompressor;
 import org.apache.parquet.hadoop.ColumnChunkPageReadStore.ColumnChunkPageReader;
 import org.apache.parquet.hadoop.ParquetFileReader.Chunk;
 import org.apache.parquet.hadoop.ParquetFileReader.ChunkPageSet;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.apache.parquet.hadoop.metadata.FileMetaData;
-import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.metadata.*;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
@@ -41,6 +39,7 @@ import org.apache.parquet.schema.MessageType;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +53,7 @@ public class ParquetFileTransformer implements Closeable {
   private final int pageSize;
   private final CompressionCodecName codecName;
   private final ParquetProperties parquetProperties;
+  private final Map<ColumnPath, ColumnDescriptor> transformerPaths;
   private final CodecFactory codecFactory;
   private final NopGroupConverter recordConverter = new NopGroupConverter();
 
@@ -67,6 +67,11 @@ public class ParquetFileTransformer implements Closeable {
     this.pageSize = pageSize;
     this.codecName = codecName;
     this.parquetProperties = new ParquetProperties(dictionaryPageSize, writerVersion, enableDictionary);
+
+    transformerPaths = new HashMap<ColumnPath, ColumnDescriptor>(transformers.size());
+    for (final ColumnDescriptor column : transformers.keySet())
+      transformerPaths.put(ColumnPath.get(column.getPath()), column);
+
     this.codecFactory = new CodecFactory(conf);
   }
 
@@ -89,7 +94,7 @@ public class ParquetFileTransformer implements Closeable {
     final FileMetaData metaData = footer.getFileMetaData();
     final MessageType schema = metaData.getSchema();
 
-    final CodecFactory.BytesCompressor compressor =
+    final BytesCompressor compressor =
         codecFactory.getCompressor(codecName, pageSize);
 
     final ParquetFileReader fileReader =
@@ -112,11 +117,34 @@ public class ParquetFileTransformer implements Closeable {
     }
   }
 
-  private void writeBlock(MessageType schema,
-                          CodecFactory.BytesCompressor compressor,
+  private void writeBlock(MessageType schema, BytesCompressor compressor,
                           ParquetFileReader fileReader,
                           ParquetFileWriter fileWriter,
                           BlockMetaData block) throws IOException {
+    if (shouldTransform(block))
+      transformBlock(schema, compressor, fileReader, fileWriter, block);
+    else
+      fileReader.appendCurrentBlock(fileWriter);
+  }
+
+  private boolean shouldTransform(BlockMetaData block) {
+    for (final ColumnChunkMetaData columnChunkMetaData : block.getColumns()) {
+      final ColumnDescriptor column =
+          transformerPaths.get(columnChunkMetaData.getPath());
+
+      final ColumnTransformer transformer = transformers.get(column);
+      if (transformer != null
+          && transformer.shouldTransform(columnChunkMetaData.getStatistics()))
+        return true;
+    }
+
+    return false;
+  }
+
+  private void transformBlock(MessageType schema, BytesCompressor compressor,
+                              ParquetFileReader fileReader,
+                              ParquetFileWriter fileWriter, BlockMetaData block)
+      throws IOException {
     fileWriter.startBlock(block.getRowCount());
 
     final ColumnChunkPageWriteStore pageWriteStore =
@@ -125,7 +153,7 @@ public class ParquetFileTransformer implements Closeable {
         parquetProperties.newColumnWriteStore(schema, pageWriteStore, pageSize);
 
     final List<Chunk> chunks = fileReader.readChunks(block);
-    for (Chunk chunk : chunks) {
+    for (final Chunk chunk : chunks) {
       final ColumnDescriptor column = chunk.getColumnDescriptor();
       final ColumnTransformer transformer = transformers.get(column);
       if (transformer != null)
@@ -171,7 +199,7 @@ public class ParquetFileTransformer implements Closeable {
     if (dictionaryPage != null)
       pageWriter.writeDictionaryPage(dictionaryPage);
 
-    for (DataPage dataPage : chunkPageSet.getDataPages())
+    for (final DataPage dataPage : chunkPageSet.getDataPages())
       try {
         dataPage.accept(visitor);
       } catch (CopyPageVisitor.PageWriteException e) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java
@@ -156,7 +156,8 @@ public class ParquetFileTransformer implements Closeable {
     for (final Chunk chunk : chunks) {
       final ColumnDescriptor column = chunk.getColumnDescriptor();
       final ColumnTransformer transformer = transformers.get(column);
-      if (transformer != null)
+      if (transformer != null
+          && transformer.shouldTransform(chunk.getStatistics()))
         transformChunk(schema, block, columnWriteStore, chunk, column,
             transformer);
       else {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/BooleanColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/BooleanColumnTransformer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.BooleanStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.schema.PrimitiveType;
 
 public abstract class BooleanColumnTransformer extends ColumnTransformerBase {
@@ -29,6 +31,16 @@ public abstract class BooleanColumnTransformer extends ColumnTransformerBase {
     super(column);
     if (column.getType() != PrimitiveType.PrimitiveTypeName.BOOLEAN)
       throw new IllegalArgumentException("Column must contain Booleans");
+  }
+
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return shouldTransform((BooleanStatistics)statistics);
+  }
+
+  protected boolean shouldTransform(BooleanStatistics statistics) {
+    return true;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/ColumnTransformerBase.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/ColumnTransformerBase.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ColumnTransformer;
 
 /**
@@ -32,6 +33,11 @@ public abstract class ColumnTransformerBase implements ColumnTransformer {
 
   public ColumnTransformerBase(ColumnDescriptor column) {
     this.column = column;
+  }
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return true;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/DoubleColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/DoubleColumnTransformer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.schema.PrimitiveType;
 
 public abstract class DoubleColumnTransformer extends ColumnTransformerBase {
@@ -29,6 +31,15 @@ public abstract class DoubleColumnTransformer extends ColumnTransformerBase {
     super(column);
     if (column.getType() != PrimitiveType.PrimitiveTypeName.INT64)
       throw new IllegalArgumentException("Column must contain doubles");
+  }
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return shouldTransform((DoubleStatistics)statistics);
+  }
+
+  protected boolean shouldTransform(DoubleStatistics statistics) {
+    return true;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/FloatColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/FloatColumnTransformer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.schema.PrimitiveType;
 
 public abstract class FloatColumnTransformer extends ColumnTransformerBase {
@@ -29,6 +31,15 @@ public abstract class FloatColumnTransformer extends ColumnTransformerBase {
     super(column);
     if (column.getType() != PrimitiveType.PrimitiveTypeName.INT64)
       throw new IllegalArgumentException("Column must contain floats");
+  }
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return shouldTransform((FloatStatistics)statistics);
+  }
+
+  protected boolean shouldTransform(FloatStatistics statistics) {
+    return true;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/IntegerColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/IntegerColumnTransformer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.schema.PrimitiveType;
 
 public abstract class IntegerColumnTransformer extends ColumnTransformerBase {
@@ -29,6 +31,15 @@ public abstract class IntegerColumnTransformer extends ColumnTransformerBase {
     super(column);
     if (column.getType() != PrimitiveType.PrimitiveTypeName.INT32)
       throw new IllegalArgumentException("Column must contain integers");
+  }
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return shouldTransform((IntStatistics)statistics);
+  }
+
+  protected boolean shouldTransform(IntStatistics statistics) {
+    return true;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/LongColumnTransformer.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/transform/LongColumnTransformer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop.transform;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.ColumnWriter;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.schema.PrimitiveType;
 
 public abstract class LongColumnTransformer extends ColumnTransformerBase {
@@ -29,6 +31,15 @@ public abstract class LongColumnTransformer extends ColumnTransformerBase {
     super(column);
     if (column.getType() != PrimitiveType.PrimitiveTypeName.INT64)
       throw new IllegalArgumentException("Column must contain long integers");
+  }
+
+  @Override
+  public boolean shouldTransform(Statistics statistics) {
+    return shouldTransform((LongStatistics)statistics);
+  }
+
+  protected boolean shouldTransform(LongStatistics statistics) {
+    return true;
   }
 
   @Override


### PR DESCRIPTION
This PR extends `ColumnTransformer` to declare a new `shouldTransform()` predicate, which accepts statistics for the column to declare its interest in proceeding transformation. If a column transformer expresses no interest [in a column](https://github.com/kissmetrics/parquet-mr/blob/40dd638c405c83b8f2268cbe625d4001d4f9a80c/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java#L160-L160), its pages are copied directly and uncompressed. If no column transformer has interest [for a given block](https://github.com/kissmetrics/parquet-mr/blob/40dd638c405c83b8f2268cbe625d4001d4f9a80c/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileTransformer.java#L124-L124), the block is copied wholesale with efficient block-level I/O.
